### PR TITLE
fix boolean logic in low mapping quality detection of PE reads

### DIFF
--- a/assemble/crop_unmapped.h
+++ b/assemble/crop_unmapped.h
@@ -37,7 +37,6 @@ hasLowMappingQuality(BamAlignmentRecord & record, int humanSeqs)
     if (record.rID != record.rNextId || abs(record.beginPos - record.pNext) >= 1000 || hasFlagRC(record) == hasFlagNextRC(record))
         return true;
 
-    // Check for non-human chromosome IDs - OUT OF DATE SINCE POPINS-v1.0.1?
     if (record.rID > humanSeqs)
         return false;
 


### PR DESCRIPTION
This **fix addresses the collecting of unaligned reads** in the _popins merge_ module. With the proposed changes two observed scenarios are now following the expected filter criteria:

1. Paired-end (PE) reads each being mapped to a different chromosome are now content of the `paired.1.fastq` / `paired.2.fastq`. For instance, before the proposed fix a PE read pair with samflags 177 and 113, mapped on chr12 and chr21 respectively, was not content of the FASTQs. Now they are.

2. Orphan reads and their unmapped mate might wrongly ended up in the  `paired.1.fastq` / `paired.2.fastq` files when supposed to be in the `single.fastq` file. For instance, before the proposed fix a read pair with samflags 117 and 185, being unmapped and mapped to chr6 respectively, is now content of the `single.fastq` and absent from the `paired.1.fastq` / `paired.2.fastq`.

The two important **changes in the code** of `assemble/crop_unmapped.h` are:

1. The negation of the boolean formula in line 37 to be compliant with the function's default return value.

2. The check for _hasNextFlagUnmapped_ in line 431 is now before the check for _hasLowMappingQuality_ in line 437. This swap seems necessary since `hasLowMappingQuality()` expects both reads in a pair to be mapped.

I only checked the surrounding code skeleton up to a certain level. It would be important to confirm that the proposed changes do not disrupt the other criteria to collect unaligned reads.
With my test BAM file (~570MB) of (un)aligned simulated PE reads, the `paired.X.fastq` files grew from 8874 to 9399 reads each and the `single.fastq` grew from 2242 to 3637 reads.